### PR TITLE
Adjusted source URL in courier-authlib.spec.in

### DIFF
--- a/courier-authlib/courier-authlib.spec.in
+++ b/courier-authlib/courier-authlib.spec.in
@@ -24,7 +24,7 @@ URL:            http://www.courier-mta.org
 
 ################################################################################
 
-Source:         http://dl.sourceforge.net/courier/%{name}-%{version}.tar.bz2
+Source:         http://downloads.sourceforge.net/courier/%{name}-%{version}.tar.bz2
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 


### PR DESCRIPTION
Hi,

Using `http://dl.sourceforge.net` results in a 404 Not Found for the source package. See [courier-authlib-0.68.0.tar.bz2](http://dl.sourceforge.net/courier/%{name}-%{version}.tar.bz2) for example. I updated the Source URL to use downloads.sourceforge.net instead.