### PR TITLE
added "Courier Unicode library" as an additional dependency.

### DIFF
--- a/courier/courier/doc/repo.html
+++ b/courier/courier/doc/repo.html
@@ -49,6 +49,10 @@
     mail server's <code>configure.in</code> script (not needed, of
     course, to build <code>sysconftool</code> itself).</li>
 
+    <li><a target="_top" href=
+    "http://www.courier-mta.org/unicode/">Courier Unicode Library</a> -
+    This library implements several algorithms related to the Unicode Standard.</li>
+
     <li>The following tools that convert Docbook XML to HTML and
     man page documentation: various Docbook DTDS, the
     "docbook-utils" tools, the "sgml-common/xml-common" package,


### PR DESCRIPTION
Courier Mail server dependencies are discussed in http://www.courier-mta.org/repo.html 
Dependencies list is almost perfect, but to build the latest sources, Courier Unicode Library is additionaly required.

For example, I tries to build courier-authlib by the following procedure, but got error.

```
$ sh INSTALLME courier-authlib https://github.com/svarshavchik/courier-libs.git
$ ./configure
$ make

(.snip)

libtool: compile:  gcc -DHAVE_CONFIG_H -I. -g -O2 -Wall -I.. -I./.. -MT rfc822_mkdate.lo -MD -MP -MF .deps/rfc822_mkdate.Tpo -c rfc822_mkdate.c -o rfc822_mkdate.o >/dev/null 2>&1
rfc2047u.c:12:10: fatal error: courier-unicode.h: No such file or directory
 #include <courier-unicode.h>
          ^~~~~~~~~~~~~~~~~~~
```

I added the additinal requirement (Courier Unicode Library) to "Git repositories" page.