### PR TITLE
fixed courier-authlib build error.

### DIFF
--- a/courier-authlib/Makefile.am
+++ b/courier-authlib/Makefile.am
@@ -366,7 +366,7 @@ authdaemondprog_DEPENDENCIES=libcourierauthcommon.la \
 	libs/liblock/liblock.la $(modules) \
 	libs/libhmac/libhmac.la libs/md5/libmd5.la libs/sha1/libsha1.la \
 	libs/rfc822/libencode.la libs/numlib/libnumlib.la
-authdaemondprog_LDADD=$(LIBLTDL) libcourierauthcommon.la libs/liblock/liblock.la \
+authdaemondprog_LDADD=$(LIBLTDL) libcourierauthcommon.la libcourierauth.la libs/liblock/liblock.la \
 	libs/libhmac/libhmac.la libs/md5/libmd5.la libs/sha1/libsha1.la \
 	libs/rfc822/libencode.la libs/numlib/libnumlib.la
 authdaemondprog_LDFLAGS=-export-dynamic $(modules:%=-dlopen %) @NETLIBS@


### PR DESCRIPTION
I tried to build courier-authlib by the following procedure, but got linker error because the lack of debug.[oc] dependency. I fixed it by changing Makefile.am.

```
$ gcc --version
gcc (Ubuntu 7.3.0-16ubuntu3) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE

$ sh INSTALLME courier-authlib https://github.com/svarshavchik/courier-libs.git
$ cd courier-authlib
$ ./configure
$ make

(.snip)

/bin/bash ./libtool  --tag=CXX   --mode=link g++  -g -O2 -Wall -Ilibs -I./libs -export-dynamic -dlopen libauthuserdb.la -dlopen libauthpwd.la -dlopen libauthshadow.la -dlopen libauthcustom.la -dlopen libauthpipe.la   -o authdaemondprog authdaemond.o authdaemondcpp.o -lltdl libcourierauthcommon.la libs/liblock/liblock.la libs/libhmac/libhmac.la libs/md5/libmd5.la libs/sha1/libsha1.la libs/rfc822/libencode.la libs/numlib/libnumlib.la 
libtool: link: rm -f .libs/authdaemondprog.nm .libs/authdaemondprog.nmS .libs/authdaemondprog.nmT
libtool: link: rm -f ".libs/authdaemondprog.nmI"
libtool: link: (cd .libs && gcc -g -O2 -Wall -Ilibs -I./libs -c -fno-builtin "authdaemondprogS.c")
libtool: link: rm -f ".libs/authdaemondprogS.c" ".libs/authdaemondprog.nm" ".libs/authdaemondprog.nmS" ".libs/authdaemondprog.nmT" ".libs/authdaemondprog.nmI"
libtool: link: g++ -g -O2 -Wall -Ilibs -I./libs .libs/authdaemondprogS.o -o .libs/authdaemondprog authdaemond.o authdaemondcpp.o -Wl,--export-dynamic  /usr/lib/x86_64-linux-gnu/libltdl.so ./.libs/libcourierauthcommon.so libs/liblock/.libs/liblock.a libs/libhmac/.libs/libhmac.a libs/md5/.libs/libmd5.a libs/sha1/.libs/libsha1.a libs/rfc822/.libs/libencode.a libs/numlib/.libs/libnumlib.a -Wl,-rpath -Wl,/usr/local/lib/courier-authlib
authdaemondcpp.o: In function `main':
/home/mumumu/build/courier/courier-authlib/authdaemondcpp.cpp:18: undefined reference to `courier_authdebug_login_init'
authdaemond.o: In function `printauth':
/home/mumumu/build/courier/courier-authlib/authdaemond.c:422: undefined reference to `courier_authdebug_authinfo'
authdaemond.o: In function `pre':
/home/mumumu/build/courier/courier-authlib/authdaemond.c:507: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:524: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:518: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:518: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:533: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:536: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:536: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:507: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:529: undefined reference to `courier_authdebug_printf'
authdaemond.o: In function `enumerate':
/home/mumumu/build/courier/courier-authlib/authdaemond.c:635: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:635: undefined reference to `courier_authdebug_printf'
authdaemond.o: In function `auth':
/home/mumumu/build/courier/courier-authlib/authdaemond.c:744: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:751: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:757: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:769: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:745: undefined reference to `courier_authdebug_login_level'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:771: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:765: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:744: undefined reference to `courier_authdebug_printf'
/home/mumumu/build/courier/courier-authlib/authdaemond.c:745: undefined reference to `courier_authdebug_login_level'
collect2: error: ld returned 1 exit status
Makefile:1151: recipe for target 'authdaemondprog' failed
make[2]: *** [authdaemondprog] Error 1
make[2]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
Makefile:1482: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
Makefile:889: recipe for target 'all' failed
make: *** [all] Error 2
```