### PR TITLE
fixed courier-authlib "make install" error on Ubuntu.

### DIFF
--- a/courier-authlib/Makefile.am
+++ b/courier-authlib/Makefile.am
@@ -17,8 +17,8 @@ pkglibexecdir=$(libexecdir)/courier-authlib
 pkglibexec_SCRIPTS=authsystem.passwd
 
 pkglib_LTLIBRARIES=libcourierauth.la \
-	libcourierauthsasl.la libcourierauthsaslclient.la \
-	libcourierauthcommon.la $(modules)
+	libcourierauthcommon.la libcourierauthsasl.la libcourierauthsaslclient.la \
+	$(modules)
 sbin_SCRIPTS=authdaemond
 sbin_PROGRAMS=authtest authenumerate authpasswd
 bin_PROGRAMS=courierauthconfig


### PR DESCRIPTION
I tried to `make install` after building courier-authlib after patching #9, but got the following error on Ubuntu 18.04 LTS.

I confirmed this error cannot be reproduced on Fedora 28.
On Ubuntu (or Debian maybe), it seems that we must specify `.la` file by dependency order.

This fix does not affect on Fedora 28.

```
$ sh INSTALLME courier-authlib https://github.com/svarshavchik/courier-libs.git
$ cd courier-authlib
$ ./configure --prefix=/home/mumumu/local
$ make
$ make install

(.snip)

make[4]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
libtool: install: /usr/bin/install -c .libs/authtest /home/mumumu/local/sbin/authtest
libtool: install: /usr/bin/install -c .libs/authenumerate /home/mumumu/local/sbin/authenumerate
libtool: warning: relinking 'libcourierauthsasl.la'
libtool: install: (cd /home/mumumu/build/courier/courier-authlib; /bin/bash "/home/mumumu/build/courier/courier-authlib/libtool"  --tag CC --mode=relink gcc -g -O2 -Wall -Ilibs -I./libs -export-symbols-regex "^auth_sasl|auth_sasl_ex|auth_sasl_extract_userid\$" -avoid-version -o libcourierauthsasl.la -rpath /home/mumumu/local/lib/courier-authlib authsasl.lo authsaslcram.lo authsasllogin.lo authsaslplain.lo authsaslfrombase64.lo authsasltobase64.lo libcourierauthcommon.la libcourierauth.la )

(... Note by mumumu, the following line is the root cause of install error. )

libtool: warning: 'libcourierauthcommon.la' has not been installed in '/home/mumumu/local/lib/courier-
authlib'

libtool: install: /usr/bin/install -c .libs/authpasswd /home/mumumu/local/sbin/authpasswd
libtool: relink: /usr/bin/nm -B  .libs/authsasl.o .libs/authsaslcram.o .libs/authsasllogin.o .libs/authsaslplain.o .libs/authsaslfrombase64.o .libs/authsasltobase64.o   | sed -n -e 's/^.*[      ]\([ABCDGIRSTW][ABCDGIRSTW]*\)[  ][      ]*\([_A-Za-z][_A-Za-z0-9]*\)$/\1 \2 \2/p' | sed '/ __gnu_lto/d' | /bin/sed 's/.* //' | sort | uniq > .libs/libcourierauthsasl.exp
libtool: relink: /bin/grep -E -e "^auth_sasl|auth_sasl_ex|auth_sasl_extract_userid$" ".libs/libcourierauthsasl.exp" > ".libs/libcourierauthsasl.expT"
libtool: relink: mv -f ".libs/libcourierauthsasl.expT" ".libs/libcourierauthsasl.exp"
libtool: relink: echo "{ global:" > .libs/libcourierauthsasl.ver
libtool: relink:  cat .libs/libcourierauthsasl.exp | sed -e "s/\(.*\)/\1;/" >> .libs/libcourierauthsasl.ver
libtool: relink:  echo "local: *; };" >> .libs/libcourierauthsasl.ver
libtool: relink:  gcc -shared  -fPIC -DPIC  .libs/authsasl.o .libs/authsaslcram.o .libs/authsasllogin.o .libs/authsaslplain.o .libs/authsaslfrombase64.o .libs/authsasltobase64.o   -Wl,-rpath -Wl,/home/mumumu/local/lib/courier-authlib -L/home/mumumu/local/lib/courier-authlib -lcourierauthcommon -lcourierauth  -g -O2   -Wl,-soname -Wl,libcourierauthsasl.so -Wl,-version-script -Wl,.libs/libcourierauthsasl.ver -o .libs/libcourierauthsasl.so
/usr/bin/x86_64-linux-gnu-ld: cannot find -lcourierauthcommon
collect2: error: ld returned 1 exit status
libtool:   error: error: relink 'libcourierauthsasl.la' with the above command before installing it
Makefile:968: recipe for target 'install-pkglibLTLIBRARIES' failed
make[3]: *** [install-pkglibLTLIBRARIES] Error 1
make[3]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
Makefile:1789: recipe for target 'install-am' failed
make[2]: *** [install-am] Error 2
make[2]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
Makefile:1483: recipe for target 'install-recursive' failed
make[1]: *** [install-recursive] Error 1
make[1]: Leaving directory '/home/mumumu/build/courier/courier-authlib'
Makefile:1783: recipe for target 'install' failed
make: *** [install] Error 2
```