### PR TITLE
Remove comma from configure error message

### DIFF
--- a/courier/courier/configure.ac
+++ b/courier/courier/configure.ac
@@ -52,7 +52,7 @@ AC_SUBST(WGET)
 
 if test ! -x "$WGET"
 then
-	AC_MSG_ERROR(wget not found, please install the wget tool)
+	AC_MSG_ERROR(wget not found please install the wget tool)
 fi
 
 AC_PATH_PROGS(COURIERAUTHCONFIG, courierauthconfig)


### PR DESCRIPTION
New wget test gives a configure-error when it has to display the wget-not-found message