### PR TITLE
Adding special TLS protocol names that disable client renegotiation.

### DIFF
--- a/cone/cone/cone.dist.in.git
+++ b/cone/cone/cone.dist.in.git
@@ -72,15 +72,13 @@ UNDERLINE_HACK=0
 #
 # OpenSSL:
 #
-# TLSv1 - TLS1
-# TLSv1.1 - TLS1.1
-# TLSv1.2 - TLS1.2
+# TLSv1 - TLS 1.0, or higher.
+# TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
+# TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
-#
-# TLSv1+, TLSv1.1+, and TLSv1.2+ - the corresponding protocol, and all
-# higher protocols.
-#
-# The default value is TLSv1+
+# The default value is TLSv1
 
 ##NAME: TLS_CIPHER_LIST:0
 #

--- a/courier/courier/courierd.dist.in.git
+++ b/courier/courier/courierd.dist.in.git
@@ -312,7 +312,9 @@ ESMTP_PREFER_IPV6_MX=1
 #
 # TLSv1 - TLS 1.0, or higher.
 # TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
 # TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
 # The default value is TLSv1
 

--- a/courier/courier/module.esmtp/esmtpd-ssl.dist.in.git
+++ b/courier/courier/module.esmtp/esmtpd-ssl.dist.in.git
@@ -176,7 +176,9 @@ COURIERTLS=@bindir@/couriertls
 #
 # TLSv1 - TLS 1.0, or higher.
 # TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
 # TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
 # The default value is TLSv1
 

--- a/courier/courier/module.esmtp/esmtpd.dist.in.git
+++ b/courier/courier/module.esmtp/esmtpd.dist.in.git
@@ -147,7 +147,9 @@ COURIERTLS=@bindir@/couriertls
 #
 # TLSv1 - TLS 1.0, or higher.
 # TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
 # TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
 # The default value is TLSv1
 


### PR DESCRIPTION
This is a follow-up to svarshavchik/courier-libs#19, a fix for #23 (for OpenSSL).

Documentation for Cone is a bit confusing, because it has some remnants of the `+` names (which are now synonyms for the non-`+` ones, it seems). I'm not sure if this is just a leftover or if there's an actual difference / intention.