### PR TITLE
Require libidn2 >= 2.0.5

### DIFF
--- a/cone/configure.ac
+++ b/cone/configure.ac
@@ -75,7 +75,7 @@ AX_COURIER_UNICODE_VERSION(2.1)
 
 dnl Checks for libraries.
 
-PKG_CHECK_MODULES(LIBIDN, libidn2 >= 0.0.0, [libidn=yes], [libidn=no])
+PKG_CHECK_MODULES(LIBIDN, libidn2 >= 2.0.5, [libidn=yes], [libidn=no])
 if test "$libidn" != "yes"
 then
 	AC_MSG_ERROR([libidn not found])


### PR DESCRIPTION
I tried building cone with different versions of libidn2 and it fails to build with version 2.0.4 or below.