### PR TITLE
Use standard perl shebang in samplepipe.pl

### DIFF
--- a/courier-authlib/samplepipe.pl
+++ b/courier-authlib/samplepipe.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl -w
 
 # This is a sample authentication module for authpipe. It uses the same
 # protocol that pop3d/imapd/webmail use to communicate with authdaemon.


### PR DESCRIPTION
For a long time, Debian has been carrying a patch to change the samplepipe.pl perl shebang to use the standard perl location.  It isn't clear to me why the sample config uses `/usr/local/bin/perl`, but I thought it might be valuable to suggest this change upstream unless there is a reason why you used the local directory.