### PR TITLE
Move webmlmd.rc to libexecdir.

### DIFF
--- a/courier/courier/Makefile.am
+++ b/courier/courier/Makefile.am
@@ -47,6 +47,7 @@ extrapkglib=makedatprog courierpop3login pcpd
 pkglibexecdir=$(libexecdir)/courier
 pkglibexec_PROGRAMS=aliasexp aliascombine aliascreate \
 		sqwebmaild submit @EXTRAPKGLIB@
+pkglibexec_SCRIPTS=webmlmd.rc
 
 webmaildir=$(libexecdir)/courier/webmail
 webmail_PROGRAMS=webmail webmlm
@@ -67,8 +68,6 @@ bin_PROGRAMS=cancelmsg mailq sendmail \
 	testmxlookup dotforward \
 	couriermlm webmlmd \
 	courier-config @couriertls@ @EXTRABIN@
-
-bin_SCRIPTS=webmlmd.rc
 
 extrasbin=couriertcpd$(EXEEXT)
 

--- a/courier/courier/perms.sh.in
+++ b/courier/courier/perms.sh.in
@@ -98,7 +98,7 @@ PERMS="
 @bindir@/couriermlm		555
 @bindir@/dotforward		555
 @bindir@/webmlmd		555
-@bindir@/webmlmd.rc		555
+@libexecdir@/webmlmd.rc		555
 
 @datadir@/makedat		555	x	bin	bin
 @bindir@/makedat		555

--- a/courier/courier/webmlmd.C
+++ b/courier/courier/webmlmd.C
@@ -37,6 +37,7 @@
 #include	<list>
 #include	<vector>
 #include	<string>
+#include	<string_view>
 #include	<algorithm>
 #include	<iostream>
 #include	<fstream>
@@ -162,9 +163,7 @@ int main(int argc, char **argv)
 		std::vector<char> shscript_v;
 
 		{
-			std::string shscript=argv[0];
-
-			shscript += ".rc";
+			std::string_view shscript=LIBEXECDIR "/webmlmd.rc";
 
 			shscript_v.reserve(shscript.size()+1);
 
@@ -182,7 +181,7 @@ int main(int argc, char **argv)
 		new_argv.insert(new_argv.end(), argv, argv+argc);
 		new_argv.push_back(0);
 
-		execve(LIBEXECDIR "/webmlmd.rc", new_argv[0], &new_argv[0]);
+		execvp(new_argv[0], &new_argv[0]);
 		perror(new_argv[0]);
 		exit(1);
 	}

--- a/courier/courier/webmlmd.C
+++ b/courier/courier/webmlmd.C
@@ -6,6 +6,7 @@
 
 #include	"config.h"
 #include	"cgi/cgi.h"
+#include	"libexecdir.h"
 #include	"rfc822/rfc822.h"
 #include	"rfc822/rfc2047.h"
 #include	"rfc2045/rfc2045.h"
@@ -181,7 +182,7 @@ int main(int argc, char **argv)
 		new_argv.insert(new_argv.end(), argv, argv+argc);
 		new_argv.push_back(0);
 
-		execvp(new_argv[0], &new_argv[0]);
+		execve(LIBEXECDIR "/webmlmd.rc", new_argv[0], &new_argv[0]);
 		perror(new_argv[0]);
 		exit(1);
 	}

--- a/courier/packaging/debian/courier-mlm-web.lintian-overrides
+++ b/courier/packaging/debian/courier-mlm-web.lintian-overrides
@@ -1,6 +1,6 @@
 #
 # Package explicitly sets these permissions
 #
-non-standard-executable-perm 0555 != 0755 [usr/lib/courier/bin/webmlmd.rc]
+non-standard-executable-perm 0555 != 0755 [usr/lib/courier/libexec/webmlmd.rc]
 non-standard-executable-perm 0555 != 0755 [usr/lib/courier/bin/webmlmd]
 non-standard-executable-perm 0555 != 0755 [usr/lib/courier/libexec/cgi-bin/webmlm]


### PR DESCRIPTION
This commit accomplishes several things.

1. It moves webmlmd.rc to @libexecdir@.
2. It updates perms.sh.in to use that directory.
3. It updates the lintian-overrides to use that directory.
4. It changes `execvp` to `execve` and adds `LIBEXECDIR "/webmlmd.rc"`.

I think item 4 is not complete, because the `webmbmd.rc` path is embedded in the `new_argv[0]` variable, but I am unsure of the best way to proceed without understanding *why* it was embedded.  Could you please advise?